### PR TITLE
Replace youtube_dl with yt-dlp

### DIFF
--- a/power_hour_creator/media.py
+++ b/power_hour_creator/media.py
@@ -12,7 +12,7 @@ from tempfile import TemporaryDirectory
 import attr
 import delegator
 import simplejson as json
-from youtube_dl import YoutubeDL, DownloadError
+from yt_dlp import YoutubeDL, DownloadError
 
 from ffmpeg_normalize.__main__ import FFmpegNormalize
 from power_hour_creator import config

--- a/power_hour_creator/ui/tracklist.py
+++ b/power_hour_creator/ui/tracklist.py
@@ -15,7 +15,7 @@ from decimal import Decimal, InvalidOperation
 
 from power_hour_creator.config import get_persistent_settings
 from power_hour_creator.media import Track, find_track
-from youtube_dl import DownloadError
+from yt_dlp import DownloadError
 
 DEFAULT_NUM_TRACKS = 60
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Easily create video or audio power hours from YouTube videos. Add your urls, pic
 Power Hour Creator automatically downloads the videos, cuts them to 60 seconds, and merges them into one file for you. Use the import and export options to share the power hour tracklists.
 
 ## Development
-Uses Python 3.6.7, PyQt 5, [youtube-dl](https://github.com/rg3/youtube-dl), ffmpeg, and [ffmpeg-normalize](https://github.com/slhck/ffmpeg-normalize).
+Uses Python 3.6.7, PyQt 5, [yt-dlp](https://github.com/yt-dlp/yt-dlp), ffmpeg, and [ffmpeg-normalize](https://github.com/slhck/ffmpeg-normalize).
 
 ## Building
 To build:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 appdirs==1.4.3
 attrs==16.3.0
-youtube_dl==2021.2.10
+yt-dlp==2021.11.10.1
 pydub==0.18.0
 PyQt5==5.15.2
 PyInstaller==3.6

--- a/tests/features/steps/create_power_hour.py
+++ b/tests/features/steps/create_power_hour.py
@@ -11,7 +11,7 @@ from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication
 from behave import *
 from hamcrest import *
-from youtube_dl import DownloadError
+from yt_dlp import DownloadError
 
 from power_hour_creator import config
 from power_hour_creator.media import MediaFile


### PR DESCRIPTION
youtube_dl appears unmaintained and downloads YT videos very slowly due
to rate limits. yt-dlp does not have this issue and is feature
compatible with youtube_dl.