### PR TITLE
Increase default max_muxing_queue_size for ffmpeg

### DIFF
--- a/power_hour_creator/media.py
+++ b/power_hour_creator/media.py
@@ -516,7 +516,7 @@ def build_audio_normalizer(output_paths):
         '--dir': False,
         '--dry-run': False,
         '--ebu': False,
-        '--extra-options': '-b:a 192k -ar 44100',
+        '--extra-options': '-b:a 192k -ar 44100 -max_muxing_queue_size 1024',
         '--force': True,
         '--format': 'wav',
         '--level': '-26',


### PR DESCRIPTION
Normalizing the volume of some videos resulted in a crash due to ffmpeg
erroring out with "Too many packets buffered for output stream".
Increasing this setting seems to solve this issue.